### PR TITLE
remove build and test in rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,3 @@ jobs:
     - uses: actions/checkout@v3
     - name: Clippy
       run: cargo clippy --verbose
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose


### PR DESCRIPTION
clippy implies build, and we have no tests yet